### PR TITLE
add unload model option

### DIFF
--- a/src/comfyui_sam3/nodes.py
+++ b/src/comfyui_sam3/nodes.py
@@ -103,9 +103,6 @@ class SAM3Segmentation:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-        # Reset mode flag
-        self.use_video_model = None
-
         print("SAM3: Model unloaded from memory")
 
     @classmethod


### PR DESCRIPTION
was being annoyed of model occupying lots of VRAM, so coded this unload_after_run toggle to unload the model from VRAM with ChatGPT help.

as a side note, multiple node instances do their own sam3 model build. quickly filling VRAM if you use different instances of the node
